### PR TITLE
Replace tailwindcss unpkg link with script cdn

### DIFF
--- a/tailwind-landing-page/index.html
+++ b/tailwind-landing-page/index.html
@@ -16,7 +16,7 @@
 		{{{$html COMMON.META.PRE_HTML}}}
 	{{/if}}
 
-	<link rel="stylesheet" href="https://unpkg.com/tailwindcss/dist/tailwind.min.css">
+	<script src="https://cdn.tailwindcss.com"></script>
 	<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
 
 	<style>


### PR DESCRIPTION
The Tailwind Landing Page is currently broken due to not being able to resolve the styles.
<img width="200" alt="image" src="https://user-images.githubusercontent.com/11362913/147331649-982b1fde-bdf8-4df1-a8ce-04060e7580cd.png">
The reason being v3 of tailwindcss [isn't able to be resolved by unpkg](https://github.com/tailwindlabs/tailwindcss/issues/6355).
The suggested way is to use the Tailwind CLI.
An alternative (albeit not intended for production) [is to use the Play CDN (what this PR uses).](https://github.com/tailwindtoolbox/Landing-Page/issues/19)
